### PR TITLE
Adds `DoNotUpdateHead` to block processing options.

### DIFF
--- a/source/MulticallModuleFactory.cs
+++ b/source/MulticallModuleFactory.cs
@@ -72,7 +72,7 @@ namespace Zoltu.Nethermind.Plugin.Multicall
 				blockTracer.StartNewBlockTrace(block);
 				/* We force process since we want to process a block that has already been processed in the past and normally it would be ignored.
 				We also want to make it read only so the state is not modified persistently in any way. */
-				Block? processedBlock = _blockProcessor.Process(block, ProcessingOptions.ForceProcessing | ProcessingOptions.ReadOnlyChain | ProcessingOptions.NoValidation, blockTracer);
+				Block? processedBlock = _blockProcessor.Process(block, ProcessingOptions.ProducingBlock, blockTracer);
 				blockTracer.EndBlockTrace();
 				return processedBlock;
 			}


### PR DESCRIPTION
This doesn't seem to be impacting us, but it feels like the correct thing to do.
```
        /// <summary>
        /// After processing it will not update the block tree head even if the processed block has the highest
        /// total difficulty.
        /// </summary>
        DoNotUpdateHead = 64,
        /// <summary>
        /// Combination of switches for block producers when they preprocess block for state root calculation.
        /// </summary>
        ProducingBlock = NoValidation | ReadOnlyChain | ForceProcessing | DoNotUpdateHead,
```